### PR TITLE
修复设置过期时间无效问题

### DIFF
--- a/adapter/adapter_redis.go
+++ b/adapter/adapter_redis.go
@@ -37,7 +37,7 @@ func (c *Redis) Set(ctx context.Context, key interface{}, value interface{}, dur
 		if duration == 0 {
 			_, err = c.redis.Ctx(ctx).DoVar("SET", key, value)
 		} else {
-			_, err = c.redis.Ctx(ctx).DoVar("SETEX", key, duration.Seconds(), value)
+			_, err = c.redis.Ctx(ctx).DoVar("SETEX", key, uint64(duration.Seconds()), value)
 		}
 	}
 	return err


### PR DESCRIPTION
操作系统：Ubuntu
golang：1.14.7
goframe:v1.15.4
在main 设置g.DB().GetCache().SetAdapter(adapter.NewRedis(g.Redis()))
使用abc.Order("weigh desc,id asc").Cache(time.Hour*24*30,"abc").FindAll() 当cache设置大于0时候无效
adapter_redis.go中duration.Seconds()长度超出范围